### PR TITLE
pass crate and unsafe in as tokens

### DIFF
--- a/iterate/src/lib.rs
+++ b/iterate/src/lib.rs
@@ -88,7 +88,11 @@ lazily. In general it tries to evaluate them lazily, but in cases where it's
 sure there will be no side effects, it evaluates `..iter` arguments eagerly.
 It does this so that it can provide a more reliable `size_hint`.
 */
-pub use iterate_proc_macro::iterate;
+pub use iterate_proc_macro::iterate as iterate_raw;
+#[macro_export]
+macro_rules! iterate {
+    ($($args:tt)*) => { $crate::iterate_raw!($crate unsafe ($($args)*)) }
+}
 
 /// The [`iterate`] macro produces a type that uses unsafe in the
 /// implementation. It is therefore critical that users of the library not


### PR DESCRIPTION
Prototype fix for #1 

Error handling is somewhat lacking (uses expect) and it could probably use some tests, but it seems to fix the issue.

Most of what I know about syn I learned in the last 3 hours writing this PR, so there's probably a better way to do this (probably defining an Input type that implements `Parse`?)

I'm out of time to work on this for the week though, so I'm uploading what I have. Feel free to take this and run with it, or close it if it's not helpful.